### PR TITLE
docs(#178): bug report document naming standards

### DIFF
--- a/bug-report-title-docs/README.md
+++ b/bug-report-title-docs/README.md
@@ -1,0 +1,13 @@
+# Guía de Nombres para Documentos de Bug Reports
+
+Este módulo documenta el formato, ejemplos y buenas prácticas para nombrar documentos de Bug Reports en el equipo de desarrollo.  
+Se divide por tipo de sistema (Frontend / Backend) y busca garantizar uniformidad, claridad y trazabilidad.
+
+## Archivos incluidos
+
+- `formato-nombres.md`: Estructura sugerida de nombres.
+- `ejemplos-frontend-backend.md`: Ejemplos correctos e incorrectos por sistema.
+- `buenas-practicas.md`: Recomendaciones para escribir títulos de manera efectiva.
+- `referencias.md`: Recursos usados como base para este estándar.
+
+**Importante:** Cada documento debe seguir la estructura definida para facilitar el seguimiento de errores y la priorización de soluciones.

--- a/bug-report-title-docs/buenas-practicas.md
+++ b/bug-report-title-docs/buenas-practicas.md
@@ -1,0 +1,22 @@
+# Buenas Prácticas para Nombres de Bug Reports
+
+## Recomendado
+
+- Seguir siempre el formato estándar definido
+- Utilizar corchetes `[ ]` para separar componentes
+- Indicar el módulo y sistema afectado
+- Describir el error de forma precisa y corta
+- Añadir versión o sprint si el error es específico a una release
+- Mantener consistencia entre títulos relacionados
+
+## ❌ Evitar
+
+- Títulos genéricos como “Error al guardar” o “No funciona”
+- Nombres vagos o sin contexto del sistema
+- Palabras ambiguas como “bug”, “problema”, “raro”
+- Abreviaciones sin definición previa
+
+## Tip 
+
+Si el bug está relacionado a varios módulos, priorizar el más afectado.  
+Ejemplo: `[Critical] [Frontend] [Login] y [Navbar] se sobreponen en pantallas móviles`

--- a/bug-report-title-docs/ejemplos-frontend-backend.md
+++ b/bug-report-title-docs/ejemplos-frontend-backend.md
@@ -1,0 +1,35 @@
+# Ejemplos de Títulos para Bug Reports
+
+## 🔹 Frontend
+
+### ✅ Correctos
+- `[High] [Frontend] [Checkout] Botón "Pagar" no responde en Chrome`
+- `[Critical] [Frontend] [Dashboard] Gráficos no cargan en Safari - v1.2.0`
+- `[Low] [Frontend] [Navbar] Íconos no se alinean en pantallas pequeñas`
+
+### ❌ Incorrectos
+- `Error en pago`
+- `Botón roto`
+- `No carga bien la UI`
+
+---
+
+## 🔹 Backend
+
+### ✅ Correctos
+- `[Critical] [Backend] [API-Orders] Error 500 al procesar pagos con PayPal`
+- `[High] [Backend] [Auth] Tokens expiran prematuramente - Sprint 10`
+- `[Low] [Backend] [User-Service] Demora al consultar historial de usuario`
+
+### ❌ Incorrectos
+- `Bug en auth`
+- `Error raro en backend`
+- `No funciona`
+
+---
+
+## Observaciones
+
+- Siempre especificar módulo funcional
+- Usar palabras claras y técnicas entendibles por todo el equipo
+- No usar abreviaciones que no estén documentadas

--- a/bug-report-title-docs/formato-nombres.md
+++ b/bug-report-title-docs/formato-nombres.md
@@ -1,0 +1,18 @@
+# Formato Estandarizado para Nombres de Bug Reports
+
+## Estructura recomendada
+
+`[Severidad] [Tipo de sistema] [Módulo] Descripción clara del problema`
+
+### Componentes:
+
+- **[Severidad]**: `[Critical]`, `[High]`, `[Low]`
+- **[Tipo de sistema]**: `[Frontend]`, `[Backend]`, `[API]`
+- **[Módulo]**: Ej. `[Login]`, `[Checkout]`, `[Dashboard]`, `[Auth]`
+- **Descripción**: Breve, directa y específica del error
+
+### Opcional:
+- Versión o sprint al final del nombre: `- v1.2.0` o `- Sprint 12`
+
+### Ejemplo:
+[High] [Frontend] [Login] Campo de contraseña no valida caracteres especiales - Sprint 14

--- a/bug-report-title-docs/referencias.md
+++ b/bug-report-title-docs/referencias.md
@@ -1,0 +1,9 @@
+# Referencias Utilizadas
+
+- [JIRA: Estándares para reportes de bugs](https://confluence.atlassian.com/jira)
+- [Azure DevOps - Nombres para Work Items](https://learn.microsoft.com/es-es/azure/devops/)
+- [Bugzilla User Guide](https://bugzilla.readthedocs.io/)
+- [Agile Alliance: Mejores prácticas de documentación](https://www.agilealliance.org)
+- Guías internas del equipo de desarrollo
+
+Estas fuentes sirvieron como base para adaptar el estándar a las necesidades del equipo, bajo un enfoque ágil y colaborativo.


### PR DESCRIPTION
### **This PR contains the documentation for task #178 focused on standardizing the naming structure of Bug Report documents.**

Includes:
- Title format explanation
- Good and bad examples (frontend and backend)
- Writing guidelines and exceptions
- References