### PR TITLE
docs(#178): bug report titles naming documentation

### DIFF
--- a/bug-report-title-docs/README.md
+++ b/bug-report-title-docs/README.md
@@ -1,13 +1,30 @@
-# Guía de Nombres para Documentos de Bug Reports
+# Estándar de Nombres para Documentos de Bug Reports
 
-Este módulo documenta el formato, ejemplos y buenas prácticas para nombrar documentos de Bug Reports en el equipo de desarrollo.  
-Se divide por tipo de sistema (Frontend / Backend) y busca garantizar uniformidad, claridad y trazabilidad.
+Este documento forma parte de la documentación técnica del equipo de desarrollo y define las normativas, buenas prácticas y estructura para nombrar correctamente los documentos de Bug Reports. Su objetivo principal es mejorar la claridad, la organización y la trazabilidad de los errores detectados tanto en frontend como backend.
 
-## Archivos incluidos
+---
 
-- `formato-nombres.md`: Estructura sugerida de nombres.
-- `ejemplos-frontend-backend.md`: Ejemplos correctos e incorrectos por sistema.
-- `buenas-practicas.md`: Recomendaciones para escribir títulos de manera efectiva.
-- `referencias.md`: Recursos usados como base para este estándar.
+## Objetivo
 
-**Importante:** Cada documento debe seguir la estructura definida para facilitar el seguimiento de errores y la priorización de soluciones.
+Establecer un formato estándar para los títulos de los documentos de errores (Bug Reports) que:
+
+- Facilite la identificación del problema desde el nombre del archivo.
+- Permita distinguir claramente la prioridad, el módulo y el tipo de sistema afectado.
+- Mantenga la consistencia entre todos los documentos del equipo.
+- Ayude a localizar y clasificar fácilmente los errores documentados.
+
+---
+
+## Contenido del Estándar
+
+La presente documentación se encuentra dividida en cinco archivos:
+
+| Archivo                             | Descripción                                                                 |
+|------------------------------------|-----------------------------------------------------------------------------|
+| `README.md`                        | Introducción general y guía de uso de esta documentación                   |
+| [`Formato-nombres.md`](./formato-nombres.md)              | Formato estándar recomendado para los títulos de documentos de bugs        |
+| [`Buenas-practicas.md`](./buenas-practicas.md)            | Normativas y buenas prácticas para mantener la coherencia en los nombres   |
+| [`Ejemplos-frontend-backend.md`](./ejemplos-frontend-backend.md) | Casos prácticos correctos e incorrectos para frontend y backend            |
+| [`Referencias.md`](./referencias.md)                    | Fuentes utilizadas y enlaces a documentación oficial sobre reporte de bugs |
+
+---

--- a/bug-report-title-docs/README.md
+++ b/bug-report-title-docs/README.md
@@ -1,0 +1,13 @@
+# Guía de Nombres para Documentos de Bug Reports
+
+Este módulo documenta el formato, ejemplos y buenas prácticas para nombrar documentos de Bug Reports en el equipo de desarrollo.  
+Se divide por tipo de sistema (Frontend / Backend) y busca garantizar uniformidad, claridad y trazabilidad.
+
+## Archivos incluidos
+
+- `formato-nombres.md`: Estructura sugerida de nombres.
+- `ejemplos-frontend-backend.md`: Ejemplos correctos e incorrectos por sistema.
+- `buenas-practicas.md`: Recomendaciones para escribir títulos de manera efectiva.
+- `referencias.md`: Recursos usados como base para este estándar.
+
+**Importante:** Cada documento debe seguir la estructura definida para facilitar el seguimiento de errores y la priorización de soluciones.

--- a/bug-report-title-docs/buenas-practicas.md
+++ b/bug-report-title-docs/buenas-practicas.md
@@ -1,0 +1,22 @@
+# Buenas Prácticas para Nombres de Bug Reports
+
+## Recomendado
+
+- Seguir siempre el formato estándar definido
+- Utilizar corchetes `[ ]` para separar componentes
+- Indicar el módulo y sistema afectado
+- Describir el error de forma precisa y corta
+- Añadir versión o sprint si el error es específico a una release
+- Mantener consistencia entre títulos relacionados
+
+## ❌ Evitar
+
+- Títulos genéricos como “Error al guardar” o “No funciona”
+- Nombres vagos o sin contexto del sistema
+- Palabras ambiguas como “bug”, “problema”, “raro”
+- Abreviaciones sin definición previa
+
+## Tip 
+
+Si el bug está relacionado a varios módulos, priorizar el más afectado.  
+Ejemplo: `[Critical] [Frontend] [Login] y [Navbar] se sobreponen en pantallas móviles`

--- a/bug-report-title-docs/buenas-practicas.md
+++ b/bug-report-title-docs/buenas-practicas.md
@@ -1,22 +1,35 @@
-# Buenas Prácticas para Nombres de Bug Reports
+# Buenas Prácticas para Nombrar Documentos de Bug Reports
 
-## Recomendado
+Este archivo recoge las principales recomendaciones que deben seguirse al momento de redactar los títulos de los documentos de Bug Reports. Estas buenas prácticas buscan mantener la coherencia, claridad y utilidad de los reportes en todo el flujo de trabajo del equipo.
 
-- Seguir siempre el formato estándar definido
-- Utilizar corchetes `[ ]` para separar componentes
-- Indicar el módulo y sistema afectado
-- Describir el error de forma precisa y corta
-- Añadir versión o sprint si el error es específico a una release
-- Mantener consistencia entre títulos relacionados
+---
 
-## ❌ Evitar
+## ✅ Recomendaciones que Sí Debes Seguir
 
-- Títulos genéricos como “Error al guardar” o “No funciona”
-- Nombres vagos o sin contexto del sistema
-- Palabras ambiguas como “bug”, “problema”, “raro”
-- Abreviaciones sin definición previa
+- Usar el formato estándar establecido en el proyecto.
+- Especificar siempre el sistema afectado (Frontend, Backend o API).
+- Indicar con claridad la prioridad o severidad del bug.
+- Describir el comportamiento observado en forma breve y directa.
+- Utilizar verbos activos y sustantivos precisos (*fails, missing, not loading, overlaps, etc.*).
+- Escribir los títulos en inglés para facilitar la lectura técnica y global del equipo.
+- Si aplica, incluir versión de la app, tipo de dispositivo o navegador afectado.
 
-## Tip 
+---
 
-Si el bug está relacionado a varios módulos, priorizar el más afectado.  
+## ❌ Prácticas que Debes Evitar
+
+- Títulos genéricos como `error`, `bug`, `problema`, `no funciona`, etc.
+- Usar palabras ambiguas como `raro`, `a veces`, `algo pasa`, `no responde bien`.
+- Incluir comentarios personales o frases informales.
+- Omitir información clave como el módulo, sistema o severidad.
+- Colocar detalles excesivos en el nombre del archivo.
+
+---
+
+## Consejos Adicionales
+
+- En herramientas como Jira o GitHub, el título del documento suele coincidir con el título del ticket. Asegúrate de que sea útil para quien lo vea sin abrir el archivo.
+- Recomendado usar plantillas o checklists para validar que tu título cumple con todos los puntos del estándar.
+- Revisa los títulos anteriores para mantener consistencia léxica (por ejemplo, no usar “Login” en un caso y “Sign in” en otro similar).
+- Si el bug está relacionado a varios módulos, priorizar el más afectado.  
 Ejemplo: `[Critical] [Frontend] [Login] y [Navbar] se sobreponen en pantallas móviles`

--- a/bug-report-title-docs/ejemplos-frontend-backend.md
+++ b/bug-report-title-docs/ejemplos-frontend-backend.md
@@ -1,0 +1,35 @@
+# Ejemplos de Títulos para Bug Reports
+
+## 🔹 Frontend
+
+### ✅ Correctos
+- `[High] [Frontend] [Checkout] Botón "Pagar" no responde en Chrome`
+- `[Critical] [Frontend] [Dashboard] Gráficos no cargan en Safari - v1.2.0`
+- `[Low] [Frontend] [Navbar] Íconos no se alinean en pantallas pequeñas`
+
+### ❌ Incorrectos
+- `Error en pago`
+- `Botón roto`
+- `No carga bien la UI`
+
+---
+
+## 🔹 Backend
+
+### ✅ Correctos
+- `[Critical] [Backend] [API-Orders] Error 500 al procesar pagos con PayPal`
+- `[High] [Backend] [Auth] Tokens expiran prematuramente - Sprint 10`
+- `[Low] [Backend] [User-Service] Demora al consultar historial de usuario`
+
+### ❌ Incorrectos
+- `Bug en auth`
+- `Error raro en backend`
+- `No funciona`
+
+---
+
+## Observaciones
+
+- Siempre especificar módulo funcional
+- Usar palabras claras y técnicas entendibles por todo el equipo
+- No usar abreviaciones que no estén documentadas

--- a/bug-report-title-docs/ejemplos-frontend-backend.md
+++ b/bug-report-title-docs/ejemplos-frontend-backend.md
@@ -1,35 +1,49 @@
-# Ejemplos de Títulos para Bug Reports
+# Ejemplos de Títulos de Bug Reports para Frontend y Backend
 
-## 🔹 Frontend
-
-### ✅ Correctos
-- `[High] [Frontend] [Checkout] Botón "Pagar" no responde en Chrome`
-- `[Critical] [Frontend] [Dashboard] Gráficos no cargan en Safari - v1.2.0`
-- `[Low] [Frontend] [Navbar] Íconos no se alinean en pantallas pequeñas`
-
-### ❌ Incorrectos
-- `Error en pago`
-- `Botón roto`
-- `No carga bien la UI`
+A continuación se presentan ejemplos prácticos de títulos bien y mal redactados para documentos de Bug Reports, divididos según el sistema afectado. 
 
 ---
 
-## 🔹 Backend
+## 🔹 Ejemplos Correctos – Frontend
 
-### ✅ Correctos
-- `[Critical] [Backend] [API-Orders] Error 500 al procesar pagos con PayPal`
-- `[High] [Backend] [Auth] Tokens expiran prematuramente - Sprint 10`
-- `[Low] [Backend] [User-Service] Demora al consultar historial de usuario`
+| Severidad  | Sistema   | Módulo     | Título                                                                 |
+|------------|-----------|------------|------------------------------------------------------------------------|
+| Critical   | Frontend  | Login      | Form does not render on Safari                                         |
+| High       | Frontend  | Checkout   | Payment button disabled on mobile devices                              |
+| Medium     | Frontend  | Dashboard  | Charts misaligned on window resize                                     |
+| Low        | Frontend  | Navbar     | Icons misaligned on iPhone SE                                          |
+| High       | Frontend  | Modal      | Close button not clickable after opening twice                         |
+| Medium     | Frontend  | Search     | Autocomplete suggestions not showing                                   |
+| Low        | Frontend  | Tooltip    | Text overflow in small resolution                                      |
 
-### ❌ Incorrectos
-- `Bug en auth`
-- `Error raro en backend`
-- `No funciona`
+> Estos títulos indican claramente el módulo, el sistema, la severidad y el comportamiento observado.
+
+## 🔹 Ejemplos Correctos – Backend
+
+| Severidad  | Sistema   | Módulo        | Título                                                                      |
+|------------|-----------|---------------|-----------------------------------------------------------------------------|
+| Critical   | Backend   | Auth          | Token validation fails for expired sessions                                 |
+| High       | Backend   | Orders        | API returns 500 error for invalid payment method                            |
+| Medium     | Backend   | Reports       | Delay in response time over 10s                                             |
+| Low        | Backend   | Notifications | Email retry mechanism fails silently                                        |
+| High       | Backend   | Payments      | Incorrect currency conversion for USD                                       |
+| Medium     | Backend   | Users         | Duplicate user ID creation in edge case                                     |
+| Low        | Backend   | Logs          | Debug logs appear in production environment  
+
+> En estos casos, se detallan errores específicos en la lógica o respuestas del servidor.
+
+## ❌ Ejemplos Incorrectos – Ambos sistemas
+
+| Título Incorrecto      | Problema                                                           |
+|------------------------|--------------------------------------------------------------------|
+| `Error en el login`    | Está en español, sin estructura ni información clara.              |
+| `Bug checkout`         | No tiene contexto ni severidad.                                    |
+| `No se muestra`        | Frase ambigua, sin indicar el módulo afectado.                     |
+| `Problema con API`     | Genérico, no describe el tipo de problema ni el comportamiento.    |
+| `Fix backend`          | Vago, sin detalles ni formato estándar.                            |
+| `Se rompe al darle click`     | Sin sistema, módulo ni lenguaje estándar.                   |
+| `pantalla se queda blanca`    | No está en inglés, y no hay descripción técnica.            |
 
 ---
 
-## Observaciones
-
-- Siempre especificar módulo funcional
-- Usar palabras claras y técnicas entendibles por todo el equipo
-- No usar abreviaciones que no estén documentadas
+> Estos ejemplos sirven como guía directa para la redacción de nuevos títulos de Bug Reports, y deben utilizarse como referencia en la validación de futuras entregas.

--- a/bug-report-title-docs/formato-nombres.md
+++ b/bug-report-title-docs/formato-nombres.md
@@ -1,0 +1,18 @@
+# Formato Estandarizado para Nombres de Bug Reports
+
+## Estructura recomendada
+
+`[Severidad] [Tipo de sistema] [Módulo] Descripción clara del problema`
+
+### Componentes:
+
+- **[Severidad]**: `[Critical]`, `[High]`, `[Low]`
+- **[Tipo de sistema]**: `[Frontend]`, `[Backend]`, `[API]`
+- **[Módulo]**: Ej. `[Login]`, `[Checkout]`, `[Dashboard]`, `[Auth]`
+- **Descripción**: Breve, directa y específica del error
+
+### Opcional:
+- Versión o sprint al final del nombre: `- v1.2.0` o `- Sprint 12`
+
+### Ejemplo:
+[High] [Frontend] [Login] Campo de contraseña no valida caracteres especiales - Sprint 14

--- a/bug-report-title-docs/formato-nombres.md
+++ b/bug-report-title-docs/formato-nombres.md
@@ -1,18 +1,71 @@
-# Formato Estandarizado para Nombres de Bug Reports
+# Formato Estándar para Nombres de Documentos de Bug Reports
 
-## Estructura recomendada
+Este archivo define el formato oficial que debe seguirse para nombrar los documentos de Bug Reports dentro del equipo. La estructura propuesta busca garantizar uniformidad y claridad, facilitando la identificación rápida del problema documentado.
 
-`[Severidad] [Tipo de sistema] [Módulo] Descripción clara del problema`
+---
 
-### Componentes:
+## Formato Recomendado
 
-- **[Severidad]**: `[Critical]`, `[High]`, `[Low]`
-- **[Tipo de sistema]**: `[Frontend]`, `[Backend]`, `[API]`
-- **[Módulo]**: Ej. `[Login]`, `[Checkout]`, `[Dashboard]`, `[Auth]`
-- **Descripción**: Breve, directa y específica del error
+[Prioridad] [Sistema] [Módulo] Descripción clara del error
 
-### Opcional:
-- Versión o sprint al final del nombre: `- v1.2.0` o `- Sprint 12`
 
-### Ejemplo:
-[High] [Frontend] [Login] Campo de contraseña no valida caracteres especiales - Sprint 14
+### Componentes del Formato:
+
+| Elemento        | Descripción                                                                  |
+|------------------|-----------------------------------------------------------------------------|
+| `[Prioridad]`    | Nivel de severidad del bug: `[Critical]`, `[High]`, `[Medium]`, `[Low]`     |
+| `[Sistema]`      | Sistema afectado: `[Frontend]`, `[Backend]`, `[API]`                        |
+| `[Módulo]`       | Área funcional afectada: `[Login]`, `[Checkout]`, `[Perfil]`, etc.          |
+| `Descripción`    | Explicación corta y precisa del comportamiento erróneo                      |
+
+---
+
+## Ejemplos Correctos 
+
+### 🔹 Frontend
+
+| Severidad  | Sistema   | Módulo     | Descripción                                                 |
+|------------|-----------|------------|-------------------------------------------------------------|
+| Critical   | Frontend  | Login      | El formulario no se muestra en Safari                       |
+| High       | Frontend  | Checkout   | Botón de pago desactivado en iPhone                         |
+| Medium     | Frontend  | Dashboard  | Los gráficos se superponen en la ventana                    |
+
+---
+
+### 🔹 Backend
+
+| Severidad  | Sistema   | Módulo     | Descripción                                                       |
+|------------|-----------|------------|-------------------------------------------------------------------|
+| Critical   | Backend   | Auth       | La validación del token falla después de iniciar sesión           |
+| High       | Backend   | Orders     | Error 500 en la solicitud de pago                                 |
+| Low        | Backend   | Reports    | Retraso de respuesta de API > 10s en v1.3.2                       |
+
+
+## ❌ Ejemplos Incorrectos
+
+| Nombre Incorrecto   | Problema                                                        |
+|---------------------|-----------------------------------------------------------------|
+| `error checkout`    | Sin prioridad, sistema ni descripción útil                      |
+| `fix bug`           | Demasiado genérico                                              |
+| `problema en login` | No indica sistema ni severidad                                  |
+| `ticket error 500`  | Falta contexto y no comunica el módulo afectado                 |
+| `Login falla`       | Incompleto y sin estructura                                     |
+
+---
+
+## Casos Especiales
+
+| Tipo de caso             | Ejemplo correcto                                                              |
+|--------------------------|-------------------------------------------------------------------------------|
+| Bug en varios sistemas   | `[Critical] [Frontend/Backend] [Profile] Data mismatch when editing info`     |
+| Afecta versión específica| `[High] [Backend] [API-Payments] Null error on v2.1.1 only`                   |
+| Errores intermitentes    | `[Medium] [Frontend] [Login] Random redirect to 404 after submit`             |
+| Problemas visuales       | `[Low] [Frontend] [Dashboard] Chart titles clipped in Firefox`                |
+
+---
+
+## Recomendaciones Generales
+
+- Mantener los nombres entre 50 y 100 caracteres.
+- Evitar el uso de términos vagos como “bug”, “error”, “falla” sin más detalles.
+- Asegurarse de que el nombre sea comprensible sin abrir el documento.

--- a/bug-report-title-docs/referencias.md
+++ b/bug-report-title-docs/referencias.md
@@ -1,0 +1,9 @@
+# Referencias Utilizadas
+
+- [JIRA: Estándares para reportes de bugs](https://confluence.atlassian.com/jira)
+- [Azure DevOps - Nombres para Work Items](https://learn.microsoft.com/es-es/azure/devops/)
+- [Bugzilla User Guide](https://bugzilla.readthedocs.io/)
+- [Agile Alliance: Mejores prácticas de documentación](https://www.agilealliance.org)
+- Guías internas del equipo de desarrollo
+
+Estas fuentes sirvieron como base para adaptar el estándar a las necesidades del equipo, bajo un enfoque ágil y colaborativo.

--- a/bug-report-title-docs/referencias.md
+++ b/bug-report-title-docs/referencias.md
@@ -1,9 +1,41 @@
 # Referencias Utilizadas
 
-- [JIRA: Estándares para reportes de bugs](https://confluence.atlassian.com/jira)
-- [Azure DevOps - Nombres para Work Items](https://learn.microsoft.com/es-es/azure/devops/)
-- [Bugzilla User Guide](https://bugzilla.readthedocs.io/)
-- [Agile Alliance: Mejores prácticas de documentación](https://www.agilealliance.org)
-- Guías internas del equipo de desarrollo
+A continuación se listan las fuentes consultadas para la elaboración del estándar de nombres de documentos de Bug Reports. Todas las referencias son oficiales, accesibles y orientadas a la correcta documentación y gestión de errores en entornos ágiles.
 
-Estas fuentes sirvieron como base para adaptar el estándar a las necesidades del equipo, bajo un enfoque ágil y colaborativo.
+---
+
+## 📘 Artículos y Documentación Oficial
+
+- **Atlassian – Seguimiento de Errores con Jira**  
+  [https://www.atlassian.com/software/jira/features/bug-tracking](https://www.atlassian.com/software/jira/features/bug-tracking)  
+  
+  Guía oficial de Atlassian sobre cómo capturar, rastrear, resolver y reportar errores utilizando Jira.
+
+- **TestLodge – How to Write a Good Bug Report**  
+  [https://blog.testlodge.com/how-to-write-a-good-bug-report/](https://blog.testlodge.com/how-to-write-a-good-bug-report/)  
+  
+  Explicación detallada sobre los elementos clave de un buen bug report, incluyendo el título.
+
+- **Azure DevOps – Definir, Capturar, Priorizar y Gestionar Errores**  
+  [https://learn.microsoft.com/es-es/azure/devops/boards/backlogs/manage-bugs](https://learn.microsoft.com/es-es/azure/devops/boards/backlogs/manage-bugs)  
+  
+  Guía de Microsoft sobre cómo gestionar errores en Azure Boards, incluyendo la captura, priorización y seguimiento de defectos de código.
+
+- **Atlassian – 4 Mejores Prácticas para el Seguimiento de Errores en Jira Service Management**  
+  [https://www.atlassian.com/incident-management/itsm/bug-tracking-best-practices](https://www.atlassian.com/incident-management/itsm/bug-tracking-best-practices)  
+  
+  Artículo que describe cómo fomentar la notificación de errores, rastrear el progreso y unir equipos para resolver errores rápidamente utilizando Jira Service Management.
+
+---
+
+## Recomendaciones de búsqueda
+
+Si alguna fuente no está disponible directamente, se recomienda buscar los siguientes términos:
+
+- `"bug report naming conventions"`
+- `"how to write bug titles"`
+- `"azure devops bugs work items"`
+
+Estas búsquedas permiten encontrar guías prácticas, plantillas y artículos relevantes desde fuentes confiables.
+
+---


### PR DESCRIPTION
### **This PR includes the full documentation for task #178 regarding naming standards for Bug Report documents.**
Includes:
- General introduction in README.md
- Format structure with examples
- Good practices and anti-patterns
- Real examples for frontend and backend (correct and incorrect)
- Verified references 