### PR TITLE
docs(#294): add task bug report documentation with template and real example

### DIFF
--- a/bug-report-tasks-docs/README.md
+++ b/bug-report-tasks-docs/README.md
@@ -1,0 +1,25 @@
+# Guía para la Creación de Tasks de Bug Report
+
+Esta guía forma parte de la estandarización técnica del equipo y tiene como objetivo establecer un formato claro, completo y reutilizable para documentar tareas relacionadas con Bug Reports en el sistema de gestión de proyectos.
+
+---
+
+## Índice
+
+- [Estructura sugerida para una Task de Bug Report](./estructura-task.md)
+- [Plantilla ejemplo de una Task](./plantilla-ejemplo.md)
+- [Checklist previo antes de enviar una Task](./checklist-previo.md)
+- [Referencias](./referencias.md)
+
+---
+
+## Propósito
+
+Asegurar que cada Task relacionada con un bug:
+
+- Sea clara, específica y fácilmente reproducible.
+- Permita al equipo de desarrollo comprender el problema sin ambigüedades.
+- Incluya evidencia suficiente y contexto de pruebas.
+- Se alinee con las convenciones del equipo y mejore la eficiencia de resolución.
+
+---

--- a/bug-report-tasks-docs/checklist-previo.md
+++ b/bug-report-tasks-docs/checklist-previo.md
@@ -1,0 +1,42 @@
+# Checklist Previo para Enviar una Task de Bug Report
+
+Este checklist debe ser revisado antes de enviar una Task de Bug Report al equipo de desarrollo.  
+Su objetivo es asegurar que la tarea tenga toda la información necesaria para reproducir, entender y resolver el error rápidamente.
+
+---
+
+## Información general
+
+| Pregunta                                                        | ✔️ |
+|-----------------------------------------------------------------|----|
+| ¿El título es claro y sigue el formato acordado?               | ☐  |
+| ¿La descripción explica qué ocurre y con qué frecuencia?        | ☐  |
+| ¿Incluiste los pasos detallados para reproducir el bug?         | ☐  |
+| ¿Comparaste el resultado esperado vs. el resultado actual?      | ☐  |
+| ¿Está claro si el bug es constante o intermitente?              | ☐  |
+
+---
+
+## Entorno y evidencia
+
+| Pregunta                                                        | ✔️ |
+|-----------------------------------------------------------------|----|
+| ¿Incluiste navegador, sistema operativo y dispositivo?          | ☐  |
+| ¿Mencionaste la versión del sistema o fecha de deploy?          | ☐  |
+| ¿Agregaste capturas de pantalla o videos?                       | ☐  |
+| ¿Pegaste errores visibles desde la consola o logs (si aplica)? | ☐  |
+| ¿Enlazaste el bug report original si fue documentado antes?     | ☐  |
+
+---
+
+## Validación final
+
+| Pregunta                                                        | ✔️ |
+|-----------------------------------------------------------------|----|
+| ¿La información es suficiente para que alguien más reproduzca el error sin preguntarte nada? | ☐  |
+| ¿Estás usando un lenguaje técnico claro y directo?              | ☐  |
+| ¿La Task puede ser tomada por un dev sin contexto adicional?    | ☐  |
+
+---
+
+> ✔️ Una Task clara y completa reduce tiempos, evita dudas y mejora el flujo entre QA y desarrollo.

--- a/bug-report-tasks-docs/estructura-task.md
+++ b/bug-report-tasks-docs/estructura-task.md
@@ -1,0 +1,71 @@
+# Estructura Estándar para una Task de Bug Report
+
+Esta estructura debe seguirse al momento de registrar un bug como Task en el sistema de gestión (como Taiga, Jira, Trello, etc.), con el fin de asegurar trazabilidad, claridad y reproducibilidad del error.
+
+---
+
+## Campos obligatorios
+
+### Título descriptivo y preciso
+- Especificar el tipo de error, módulo afectado y sistema.
+- Usar el formato definido en la guía de nombres de bug reports.
+
+**Ejemplo**:  
+`[High] [Frontend] [Checkout] Payment button not responding on Chrome`
+
+---
+
+### Descripción del error
+- Describir claramente el comportamiento observado.
+- Indicar si el error es constante o intermitente.
+- Evitar términos vagos como “no funciona”.
+
+---
+
+### Pasos para reproducir el bug
+- Enumerar paso por paso lo necesario para llegar al error.
+- Ser lo más específico posible.
+
+**Ejemplo**:
+1. Iniciar sesión como usuario cliente.
+2. Navegar al módulo de Checkout.
+3. Seleccionar método de pago y hacer clic en “Pagar”.
+4. El botón no responde ni muestra feedback visual.
+
+---
+
+### Resultado esperado vs resultado actual
+- Qué debería ocurrir vs. qué ocurre realmente.
+
+**Ejemplo**:  
+- ✅ **Esperado**: Al hacer clic en “Pagar”, se procesa el pago y se muestra una pantalla de confirmación.  
+- ❌ **Actual**: No ocurre ninguna acción al presionar el botón.
+
+---
+
+### Contexto del entorno de pruebas
+- Navegador, dispositivo, sistema operativo, fecha, versión del sistema.
+
+**Ejemplo**:
+- Chrome v124.0, Windows 10, resolución 1366x768, Sprint 17 (deploy del 12/04/2025).
+
+---
+
+### Evidencia visual
+- Capturas de pantalla, video o grabación de pantalla (Loom, XRecorder, etc.).
+- Adjuntar archivos si es posible o incluir links.
+
+---
+
+### Logs / Mensajes de consola (si aplica)
+- Copiar el error desde la consola si es visible.
+- Adjuntar fragmentos JSON, tracebacks u otros detalles técnicos útiles.
+
+---
+
+### Enlace al Bug Report original (opcional)
+- Si el bug ya fue documentado por otro canal (formulario, planilla, etc.), incluir el link directo para referencia.
+
+---
+
+> ⚠️ Las tasks sin esta información corren el riesgo de ser rechazadas o quedar en revisión indefinida.

--- a/bug-report-tasks-docs/plantilla-ejemplo.md
+++ b/bug-report-tasks-docs/plantilla-ejemplo.md
@@ -1,0 +1,67 @@
+# Plantilla Ejemplo para Registrar una Task de Bug Report
+
+Se recomienda copiar y pegar esta plantilla al crear una Task en el sistema de gestión (Taiga, Jira, etc.), reemplazando el contenido entre paréntesis.
+Durante la revisión de tareas anteriores, se identificaron errores comunes como descripciones vagas, ausencia de pasos reproducibles o títulos genéricos, lo cual motivó la creación de esta guía.
+
+---
+
+## Título
+
+`[Severidad] [Sistema] [Módulo] Descripción breve del error`
+
+**Ejemplo**:  
+`[High] [Frontend] [Login] Button freezes after clicking 'Submit' on mobile`
+
+---
+
+## Descripción del error
+
+(Describe el comportamiento observado del sistema. Indica si el error es constante o intermitente.)
+
+**Ejemplo**:  
+Después de rellenar el formulario de acceso y hacer clic en «Enviar», la página se bloquea y no se muestra ninguna respuesta. El problema se produce sistemáticamente en los navegadores móviles.
+
+---
+
+## Pasos para reproducirlo
+
+1. Vaya a la página de inicio de sesión.
+2. Introducir credenciales válidas.
+3. Haga clic en el botón «Enviar».
+4. Observe la congelación y la falta de respuesta.
+
+---
+
+## Resultado esperado vs actual
+
+- **Esperado**: El usuario es redirigido al panel de control tras iniciar sesión correctamente.
+- **Actual**: El botón se congela y no ocurre nada.
+
+---
+
+## Entorno de pruebas
+
+- Browser: Safari 16.2
+- OS: iOS 17.3.1
+- Device: iPhone 13 mini
+- App version: v2.5.3 (deploy 11/04/2025)
+
+---
+
+## Evidencia
+
+(Screenshot o link a Loom, XRecorder u otra grabación)  
+Ejemplo: https://loom.com/share/bug-login-submit-freeze
+
+---
+
+## Logs / Consola
+
+Uncaught TypeError: Cannot read properties of undefined (reading 'token') at submitLogin (login.js:48)
+
+---
+
+## Enlace al Bug Report (opcional)
+
+(Si ya se documentó en otra herramienta o Excel, incluir aquí el enlace)  
+Ejemplo: https://drive.google.com/bug-report-login-v253

--- a/bug-report-tasks-docs/plantilla-ejemplo.md
+++ b/bug-report-tasks-docs/plantilla-ejemplo.md
@@ -1,11 +1,11 @@
 # Plantilla Ejemplo para Registrar una Task de Bug Report
 
-Se recomienda copiar y pegar esta plantilla al crear una Task en el sistema de gestión (Taiga, Jira, etc.), reemplazando el contenido entre paréntesis.
+Se recomienda copiar y pegar esta plantilla al crear una Task en el sistema de gestión (Taiga, Jira, etc.), reemplazando el contenido entre paréntesis.  
 Durante la revisión de tareas anteriores, se identificaron errores comunes como descripciones vagas, ausencia de pasos reproducibles o títulos genéricos, lo cual motivó la creación de esta guía.
 
 ---
 
-## Título
+## TÍTULO
 
 `[Severidad] [Sistema] [Módulo] Descripción breve del error`
 
@@ -14,7 +14,7 @@ Durante la revisión de tareas anteriores, se identificaron errores comunes como
 
 ---
 
-## Descripción del error
+## DESCRIPCIÓN DEL ERROR
 
 (Describe el comportamiento observado del sistema. Indica si el error es constante o intermitente.)
 
@@ -23,7 +23,7 @@ Después de rellenar el formulario de acceso y hacer clic en «Enviar», la pág
 
 ---
 
-## Pasos para reproducirlo
+## PASOS PARA REPRODUCIRLO
 
 1. Vaya a la página de inicio de sesión.
 2. Introducir credenciales válidas.
@@ -32,36 +32,75 @@ Después de rellenar el formulario de acceso y hacer clic en «Enviar», la pág
 
 ---
 
-## Resultado esperado vs actual
+## RESULTADO ESPERADO VS ACTUAL
 
 - **Esperado**: El usuario es redirigido al panel de control tras iniciar sesión correctamente.
 - **Actual**: El botón se congela y no ocurre nada.
 
 ---
 
-## Entorno de pruebas
+## ENTORNO DE PRUEBAS
 
-- Browser: Safari 16.2
-- OS: iOS 17.3.1
-- Device: iPhone 13 mini
+- Browser: Safari 16.2  
+- OS: iOS 17.3.1  
+- Device: iPhone 13 mini  
 - App version: v2.5.3 (deploy 11/04/2025)
 
 ---
 
-## Evidencia
+## EVIDENCIA
 
 (Screenshot o link a Loom, XRecorder u otra grabación)  
 Ejemplo: https://loom.com/share/bug-login-submit-freeze
 
 ---
 
-## Logs / Consola
+## LOGS / CONSOLA
 
-Uncaught TypeError: Cannot read properties of undefined (reading 'token') at submitLogin (login.js:48)
+`Uncaught TypeError: Cannot read properties of undefined (reading 'token') at submitLogin (login.js:48)`
 
 ---
 
-## Enlace al Bug Report (opcional)
+## ENLACE AL BUG REPORT (opcional)
 
 (Si ya se documentó en otra herramienta o Excel, incluir aquí el enlace)  
 Ejemplo: https://drive.google.com/bug-report-login-v253
+
+---
+
+## EJEMPLO COMPLETO SIMULADO (LOGIN)
+
+Este ejemplo representa cómo se debería documentar un bug real:
+
+---
+
+### Título  
+`[High] [Frontend] [Login] Login fails with correct credentials`
+
+### Descripción  
+Cuando el usuario intenta iniciar sesión con credenciales correctas, el sistema muestra un mensaje de error de “contraseña incorrecta” aunque los datos sean válidos. El error ocurre siempre en dispositivos móviles.
+
+### Pasos para reproducir  
+1. Ir a la pantalla de inicio de sesión  
+2. Ingresar el email `user@test.com` y contraseña correcta  
+3. Presionar “Iniciar Sesión”  
+4. Aparece mensaje de error: “Invalid password”
+
+### Resultado esperado vs actual  
+- **Esperado**: Usuario accede al dashboard correctamente  
+- **Actual**: Se muestra error de contraseña y no se accede
+
+### Entorno de pruebas  
+- Browser: Chrome 123  
+- OS: Android 13  
+- Device: Pixel 6  
+- App version: v2.5.3 (deploy 13/04/2025)
+
+### Evidencia  
+Captura adjunta + grabación Loom: `https://loom.com/share/login-error-test`
+
+### Logs / Consola  
+`401 Unauthorized: Token rejected for user ID 101`
+
+### Enlace al Bug Report (opcional)  
+_No documentado previamente_

--- a/bug-report-tasks-docs/referencias.md
+++ b/bug-report-tasks-docs/referencias.md
@@ -1,0 +1,42 @@
+# Referencias Utilizadas
+
+A continuación se listan las fuentes utilizadas para la elaboración de esta guía sobre la creación y gestión de Tasks de Bug Reports. Todas las referencias apuntan a buenas prácticas de QA, gestión de errores y documentación técnica aplicable a equipos ágiles.
+
+---
+
+## Artículos y Documentación Oficial
+
+- **GitHub Docs – Creating an issue**  
+  https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue  
+  Instrucciones de GitHub sobre cómo crear issues claros, que aplican al registro de bugs como tareas.
+
+- **Google Testing Blog – How Google Tests Software**  
+  https://testing.googleblog.com/  
+  Enfoques utilizados por Google para pruebas de software, incluyendo gestión de errores.
+
+- **BrowserStack – How to Write a Good Bug Report**  
+  https://www.browserstack.com/guide/how-to-write-a-bug-report 
+  Guía completa sobre cómo redactar bug reports útiles, reproducibles y bien estructurados.
+
+- **Testlio – 7 Elements of a Great Bug Report**  
+  https://testlio.com/blog/the-ideal-bug-report/  
+  Buenas prácticas para asegurar que un reporte de error sea claro y valioso para el equipo de desarrollo.
+
+---
+
+## 🔍 Términos recomendados para búsqueda adicional
+
+- "how to write actionable bug reports"
+- "QA bug report checklist"
+- "software bug report template"
+
+---
+
+## Aplicación
+
+Estas referencias fueron utilizadas para:
+
+- Definir la estructura estándar de una Task de Bug Report.
+- Establecer los campos obligatorios mínimos.
+- Diseñar una plantilla reutilizable para el equipo QA.
+- Construir un checklist que permita validar la completitud del reporte antes de enviarlo a desarrollo.


### PR DESCRIPTION
### **This PR includes the documentation for task creation standards for Bug Reports as defined in User Story #294.**

Included:
- Editable template to register Bug Report tasks following consistent structure.
- Instructions for each section to ensure clarity and completeness.
- A real simulated example based on a Login error, demonstrating how to apply the template.
- Structured documentation ready for use in task managers like Taiga or Jira.
